### PR TITLE
page-016.tex: typos, one French word

### DIFF
--- a/page-016.tex
+++ b/page-016.tex
@@ -39,16 +39,16 @@ your hand confused.
 % förskränkter ???] kropp.
 
 If his point is not higher than your right shoulder / bind with half
-fourth; if his point is towards your girdle, bind in third amd
+fourth; if his point is towards your girdle, bind in third and
 slightly depressed point. But if his point is in-between, slightly
 high, bind with a slightly raised point, so that you move his line so
 that you are safe from the line that comes from his point to your
 body. If he is lower and in third, bind him with a hanging third or
 fourth, inside with fourth, outside with half second. But if his blade
 is turned inwards, or angled that way, bind him on the outside,
-apprximately with half second or half fourth, while his point is no
+approximately with half second or half fourth, while his point is no
 lower than your genitals, you should remain with binding with a
-hanging third. You may stay on the outside against both high and unde
+hanging third. You may stay on the outside against both high and under
 the guard with the whole fourth bind, especially when you fence with a
 lowered body.
 
@@ -71,13 +71,14 @@ lowered body.
 
 Even If your Enemy uses these mutations multiple times, you must not
 become impatient, but proceed with caution until you get measure and
-tempo to thrust (likewise can binding or Cotrapostur with a strong
+tempo to thrust (likewise can binding or Contrapostur with a strong
 body be performed) with exquisite usefulness and advantage against
 your Enemy be adopted. 1. when he Beats, he finds that your openings
 are gone and you can at that time close on him 2. The further your
 left Shoulder is forward / the stronger you are with your blade / so
-that you can go deeper into measire and your body out of danger 3. If
-the enemy cannot pass your blade 5. You are in this way safer against
+that you can go deeper into measure and your body out of danger 3. If
+the enemy cannot pass your blade [4. he can not as well as otherwise use the left hand.]
+5. You are in this way safer against
 an angled guard, since both openings, the outward as well as the
 inward are well guarded. But note that this manner that you turn the
 toes of your right foot outwards in the moment you lower your body so
@@ -97,11 +98,10 @@ that you more easily can lower your body.
 As far as Ligering\sidenote{Both ``ligera'' and ``stringera''
 translate to `bind'} is concerned / it is nothing but a Contrapostur,
 with prior bending of the body without
-bending\sidenote{``abaissering'', no actual translation found} the
-arm, with a dangling Blade to the Enemy's weak / and thus his point
+lowering the arm, with a dangling Blade to the Enemy's weak / and thus his point
 closed off; you should note that you bind with the whole second
 against the lower guard and half second against the high guard. If you
 have bound and want to close off his blade to the outside / step
 slightly to his right, out of dangling Third, outside in the hanging
-second and you have Bound his blade. When you otherwaise want to
+second and you have Bound his blade. When you otherwise want to
 Bind on the outside, you must with your blade well


### PR DESCRIPTION
Translate "abbaissering" as the French word [abbaisser](https://www.dictionnaire-academie.fr/article/A1B0067-02) (to lower).

I also added a missing 4th section of a long sentence. Perhaps this is connected to an image plate? I don't know, but with the text present in the file, I made a rough translation and placed it between brackets, to denote me not being too sure about it.