### PR TITLE
page-037.tex: some typos, some word choice

### DIFF
--- a/page-037.tex
+++ b/page-037.tex
@@ -24,21 +24,20 @@
 % secunda under hans klinga fort.
 
 and a strong impetus, pass immediately in one tempo with the whole
-body somewhan halved over his Blade to his Breast / guard yourself
+body somewhat halved over his Blade to his Breast / guard yourself
 below in Third / angle your body slightly / and in the same moment
-pretend to give him a thrust on the inside / upheave\sidenote{cancel?
-heave up?}
-your Blade quickly / beat and pass him with fourth on the inside to
+pretend to give him a thrust on the inside / quickly lift up 
+your Blade / beat and pass him with fourth on the inside to
 his Breast; If you want to do these on the inside so do the Feint on
 the outside when his Cross / he parries / so void / and press his
 blade with both hands to the Earth / to his right his cross; Pass with
 haste on the inside to his Breast. Sometimes those who cannot fence /
 that they go high with Blade and Point in presentation; When this
-happens / cooperate and cover yoursefl under his Blade / on the
+happens / cooperate and cover yourself under his Blade / on the
 outside with Second / on the inside with a deep position / go
 immediately with your Blade under his well-covered / quickly to his
-openng. You can now do him a Feint on the inside in Fourth, and in the
-moment he thrusts into your Feint, Void beside it  / beat his blade
+opening. You can now do him a Feint on the inside in Fourth, and in the
+moment he thrusts into your Feint, Void beside it / beat his blade
 out of his hand / pass with second under his blade quickly.
 
 % Enteligen då din Wederpart brukar wänstre handen / måtte du intet
@@ -48,7 +47,7 @@ out of his hand / pass with second under his blade quickly.
 % klinga / eller på dig passera; När du förer din udd lågt eller
 % försänkt / giör du stöterna opföre.
 
-When eventually your Opponent uses the left hand / you must not thrust
+Finally, when your Opponent uses the left hand / you must not thrust
 in a straight line, but move your blade in a feinting manner / and
 always be ready to void the blade, you carry your blade somewhat high
 / or somewhat angled, so that he cannot get your blade / or pass you;
@@ -64,12 +63,11 @@ When you bring your point low / you should thrust upwards.
 % fall han har intet hafft tempo att bryta mensuram.
 
 But still that you don't start your thrust / let your point go straight to
-his opening / that you through measure and tempo intend to reach  /
-but the proportion to wich you come with the point into the thrust /
-the same adress so that when he in such manner has hiddent the opening
-/ tha the thrust in that moment is completed / you will with your
-point his left hand [evitera??]\sidenote{I have no idea what this
-means, avoid?}, and he doesn't know how he shall find it / unable to
+his opening / that you through measure and tempo intend to reach /
+but the proportion to which you come with the point into the thrust /
+the same address so that when he in such manner has hidden the opening
+/ that the thrust in that moment is completed / you will with your
+point his left hand avoid, and he doesn't know how he shall find it / unable to
 even parry; In case he has not had tempo to break measure.
 
 % Item tiänar och att man stöterna utan / så wäl som innan till hans
@@ -78,15 +76,15 @@ even parry; In case he has not had tempo to break measure.
 % wijd dett samma han will parera effter din klinga  låter honom taga
 % mistom / och effter lägenheet antignen under eller öfwer den samma
 % caverar, eller udden emellan hans bägge Armar låter insiunka / och
-% förblifwer med korset betäckt wijd hand klinga / och bruka dig innan
+% förblifwer med korset betäckt wijd hans klinga / och bruka dig innan
 % till för större säkerheet skull dett falska steget.
 
 Also serves that one thrusts on the out- as well as inside his body
 angles, thus they will be much harder for him to parry; You can betray
 his left hand with a Feint, in that you him / with him wanting to
-then parry after your blade let him mistake / andbased on  opportunity
-either underneath or above it void, or the pont between his Arms let
-sink in / and remain with the cross whi hand and blade / and bring
+then parry after your blade let him mistake / and based on opportunity
+either underneath or above it void, or the point between his Arms let
+sink in / and remain covered with the cross at his blade / and bring
 yourself inside for sake of larger security the false step.
 
 % Ibland detta är och i acht tagandes / att man offta / när en brukar


### PR DESCRIPTION
Mention of evitera in the sense "avoid":
https://svenska.se/saob/?id=V_0233-0029.t4j6

Yeah, and eviter means "to avoid" in French.
https://www.google.com/search?client=firefox-b-d&q=eviter+francais

I think "hans", not "hand".